### PR TITLE
Keep uploaded files locally, don't wait for upload to complete when creating file

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,6 @@
 	<namespace>Files_External_Sia</namespace>
 
 	<dependencies>
-		<lib>Sia</lib>
 		<owncloud min-version="9.1" max-version="9.1"/>
 		<nextcloud min-version="10" max-version="12"/>
 	</dependencies>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -2,14 +2,16 @@
 <info>
 	<id>files_external_sia</id>
 	<name>Sia storage support</name>
-	<description>Sia support for files_external. This app adds a dropdown for Sia, a decentralized storage network, to the files_external app. A running, correctly configured Sia node is required for this app.</description>
+	<description>Sia support for files_external. This app adds a dropdown for Sia, a decentralized storage network, to the files_external app.</description>
 	<licence>AGPL</licence>
 	<author>Nebulous Labs</author>
 	<version>0.1.0</version>
-	<screenshot>https://sia.tech//img/siainfo3.png</screenshot>
 	<documentation>
 		<user>https://github.com/NebulousLabs/Sia-Nextcloud</user>
 	</documentation>
+	<bugs>https://github.com/NebulousLabs/Sia-Nextcloud/issues</bugs>
+	<repository>https://github.com/NebulousLabs/Sia-Nextcloud</repository>
+	<screenshot>https://sia.tech//img/siainfo3.png</screenshot>	
 	<types>
 		<filesystem/>
 	</types>

--- a/lib/Backend/Sia.php
+++ b/lib/Backend/Sia.php
@@ -38,7 +38,7 @@ class Sia extends Backend {
 			->setText($l->t('Sia'))
 			->addParameters([
 				(new DefinitionParameter('apiaddr', $l->t('API Address'))),
-				(new DefinitionParameter('datadir', $l->t('Renter Data Directory')),
+				(new DefinitionParameter('datadir', $l->t('Renter Data Directory'))),
 			])
 			->setAllowedVisibility(BackendService::VISIBILITY_ADMIN)
 			->setPriority(BackendService::PRIORITY_DEFAULT + 50)

--- a/lib/Backend/Sia.php
+++ b/lib/Backend/Sia.php
@@ -38,6 +38,7 @@ class Sia extends Backend {
 			->setText($l->t('Sia'))
 			->addParameters([
 				(new DefinitionParameter('apiaddr', $l->t('API Address'))),
+				(new DefinitionParameter('datadir', $l->t('Renter Data Directory')),
 			])
 			->setAllowedVisibility(BackendService::VISIBILITY_ADMIN)
 			->setPriority(BackendService::PRIORITY_DEFAULT + 50)

--- a/lib/Storage/Sia.php
+++ b/lib/Storage/Sia.php
@@ -43,7 +43,7 @@ class Sia extends \OC\Files\Storage\Common {
 		}
 		$this->client = new \Sia\Client($arguments['apiaddr']);
 		$this->apiaddr = $arguments['apiaddr'];
-		$this->datadir = $arguments['datadir'];
+		$this->datadir = realpath($arguments['datadir']);
 	}
 
 	// parsePaths takes an array of siafiles and a path and returns an array of
@@ -320,7 +320,7 @@ class Sia extends \OC\Files\Storage\Common {
 			case 'x+':
 			case 'c':
 			case 'c+':
-				$localfile = $this->datadir . basename($path);
+				$localfile = $this->datadir . '/' . basename($path);
 				$handle = fopen($localfile, $mode);
 				return CallbackWrapper::wrap($handle, null, null, function () use ($path, $localfile) {
 					$this->client->upload($path, $localfile);

--- a/lib/Storage/Sia.php
+++ b/lib/Storage/Sia.php
@@ -34,6 +34,7 @@ use Icewind\Streams\CallbackWrapper;
 class Sia extends \OC\Files\Storage\Common {
 	private $client;
 	private $apiaddr;
+	private $datadir
 
 
 	public function __construct($arguments) {
@@ -42,6 +43,7 @@ class Sia extends \OC\Files\Storage\Common {
 		}
 		$this->client = new \Sia\Client($arguments['apiaddr']);
 		$this->apiaddr = $arguments['apiaddr'];
+		$this->datadir = $arguments['datadir'];
 	}
 
 	// parsePaths takes an array of siafiles and a path and returns an array of
@@ -128,11 +130,14 @@ class Sia extends \OC\Files\Storage\Common {
 	}
 
 	// test the node's upload capability by verifying that the node has some
-	// contracts.
+	// contracts and the renter data directory is writeable.
 	public function test() {
 		try {
 			$contracts = $this->client->renterContracts();
 			if (count($contracts) === 0) {
+				return false;
+			}
+			if (!is_writeable($this->datadir)) {
 				return false;
 			}
 			return true;

--- a/lib/Storage/Sia.php
+++ b/lib/Storage/Sia.php
@@ -34,7 +34,7 @@ use Icewind\Streams\CallbackWrapper;
 class Sia extends \OC\Files\Storage\Common {
 	private $client;
 	private $apiaddr;
-	private $datadir
+	private $datadir;
 
 
 	public function __construct($arguments) {
@@ -320,20 +320,10 @@ class Sia extends \OC\Files\Storage\Common {
 			case 'x+':
 			case 'c':
 			case 'c+':
-				$tmpFile = \OCP\Files::tmpFile();
-				$handle = fopen($tmpFile, $mode);
-				return CallbackWrapper::wrap($handle, null, null, function () use ($path, $tmpFile) {
-					$this->client->upload($path, $tmpFile);
-					while (true) {
-						$siafiles = $this->client->renterFiles();
-						foreach($siafiles as $siafile) {
-							if ($siafile->siapath === $path && $siafile->available) {
-								unlink($tmpFile);
-								return;
-							}
-						}
-						sleep(1);
-					}
+				$localfile = $this->datadir . basename($path);
+				$handle = fopen($localfile, $mode);
+				return CallbackWrapper::wrap($handle, null, null, function () use ($path, $localfile) {
+					$this->client->upload($path, $localfile);
 				});
 		}
 	}


### PR DESCRIPTION
This PR fixes #4, keeping the files on the nextcloud server in a new configuration field, `datadir`. Doing this is necessary until the renter supports not having the files locally. I also tweaked the `c+` mode of fopen to be more performant.