### PR TITLE
large performance and ux improvements

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<description>Sia support for files_external. This app adds a dropdown for Sia, a decentralized storage network, to the files_external app.</description>
 	<licence>AGPL</licence>
 	<author>Nebulous Labs</author>
-	<version>0.1.1</version>
+	<version>0.1.2</version>
 	<documentation>
 		<user>https://github.com/NebulousLabs/Sia-Nextcloud</user>
 	</documentation>

--- a/lib/Storage/Sia.php
+++ b/lib/Storage/Sia.php
@@ -9,8 +9,8 @@
  * This code is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License, version 3,
  * as published by the Free Software Foundation.
- * This program is distributed in the hope that it will be useful,
  *
+ * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
@@ -84,6 +84,9 @@ class Sia extends \OC\Files\Storage\Common {
 		return array_values($ret);
 	}
 
+	// localFile takes a $siapath and returns the location of the file on disk.
+	// Temporary files ('.octransfer*') will have the same hash as their final
+	// forms.
 	private function localFile($siapath) {
 		$cleanpath = $siapath;
 		if (strpos($siapath, '.ocTransferId') !== false) {

--- a/lib/Storage/Sia.php
+++ b/lib/Storage/Sia.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @copyright Copyright (c) 2016, Nebulous, Inc.
  *
  * @author Johnathan Howell <me@johnathanhowell.com>
  *
@@ -9,7 +9,7 @@
  * This code is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License, version 3,
  * as published by the Free Software Foundation.
- * * This program is distributed in the hope that it will be useful,
+ * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.


### PR DESCRIPTION
This PR makes large gains in perceived performance by storing the files on disk as the hash of their siapath, and using those on-disk files to serve image previews. The integration now checks if the node has a copy of the requested file before downloading it, removing unnecessary and slow download calls mentioned in #6. Unnecessary spinning to wait for downloads to complete has also been removed, instead the integration will simply return a 'this file is being downloaded' file if a file being downloaded is requested.

